### PR TITLE
Price rounding

### DIFF
--- a/lumiwealth_tradier/orders.py
+++ b/lumiwealth_tradier/orders.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from typing import Union
 
@@ -241,9 +242,9 @@ class Orders(TradierApiBase):
     @staticmethod
     def _update_order_payload(payload, limit_price, order_type, stop_price, tag):
         if order_type.lower() == "limit" or order_type.lower() == "stop_limit":
-            payload["price"] = limit_price
+            payload["price"] = round(limit_price, 2)
         if order_type.lower() == "stop" or order_type.lower() == "stop_limit":
-            payload["stop"] = stop_price
+            payload["stop"] = round(stop_price, 2)
         if tag:
             payload["tag"] = tag
 

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -69,7 +69,7 @@ class TestMarket:
             tradier.market.get_timesales('SPY', start_date=start_date, end_date=end_date)
 
     def test_option_expirations(self, tradier):
-        df = tradier.market.get_option_expirations('SPY')
+        df = tradier.market.get_option_expirations('SPY', include_all_roots=True)
         assert df is not None
         assert len(df) > 0
         assert 'strikes' in df.columns

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from lumiwealth_tradier.base import TradierApiError
 from lumiwealth_tradier.tradier import Tradier
 
 
@@ -35,7 +36,7 @@ class TestOrders:
 
     def test_stock_order(self, tradier):
         # Invalid side for stocks
-        with pytest.raises(ValueError):
+        with pytest.raises(TradierApiError):
             tradier.orders.order(symbol='AAPL', quantity=1, side='buy_to_open', order_type='market', tag='unittest')
 
         # Submit basic order


### PR DESCRIPTION
Round limit/stop prices to prevent floating point repeating digits from causing Tradier to reject orders.