### PR TITLE
Retry get requests on error or on no data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,22 @@ To contribute or make changes to the `lumiwealth-tradier` package, feel free to 
 
   `cd lumiwealth-tradier`
 
-- If you need to be careful about dependencies, create a new Python virtual environment: <br>
+- Add the original repository as a remote:
 
-  `python -m venv replace_this_with_desired_venv_name` [Mac] <br>
-  
-  `venv\Scripts\activate` [Windows]
+  `git remote add upstream https://github.com/Lumiwealth/lumiwealth-tradier`
+
+- Confirm the remote has been added:
+
+  `git remote -v`
+
+- Create a new branch for your feature:
+
+  `git checkout -b feature_branch_name`
+
+- If you need to be careful about dependencies, create a new Python virtual environment and activate it:
+
+  `python -m venv venv`
+  `venv\Scripts\activate`
 
 - Install the required dev dependencies:
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,25 @@ To contribute or make changes to the `lumiwealth-tradier` package, feel free to 
   
   `venv\Scripts\activate` [Windows]
 
+- Install the required dev dependencies:
+
+  `pip install -r requirements_dev.txt`
+
+- Install the package in editable mode:
+
+  `pip install -e .`
+
+- Create a `.env` file in the root directory and add your Tradier account number and access token.
+
+- Add the following vars for testing:
+
+    `TRADIER_ACCOUNT_NUMBER=<YOUR_ACCOUNT_NUMBER_FROM_TRADIER_DASHBOARD>`
+    `TRADIER_PAPER_TOKEN=<YOUR_PAPER_ACCESS_TOKEN_FROM_TRADIER_DASHBOARD>`
+
+- Finally, run the tests:
+
+  `pytest`
+
 ## Questions?
 
 Happy to help! Feel free to contact Robert Grzesik by email at <EMAIL?>. <br>

--- a/lumiwealth_tradier/market.py
+++ b/lumiwealth_tradier/market.py
@@ -1,10 +1,13 @@
 import datetime as dt
 from typing import Union
 from time import sleep
+import logging
 
 import pandas as pd
 
 from .base import TradierApiBase, DEFAULT_RETRY_ATTEMPTS
+
+logger = logging.getLogger(__name__)
 
 
 class MarketData(TradierApiBase):
@@ -130,6 +133,7 @@ class MarketData(TradierApiBase):
             if response["history"] and "day" in response["history"]:
                 break
             else:
+                logger.info(f"No data for {symbol} from get_historical_quotes. Retrying.")
                 sleep(1)
 
         if response["history"] is None or "day" not in response["history"]:

--- a/lumiwealth_tradier/market.py
+++ b/lumiwealth_tradier/market.py
@@ -59,8 +59,16 @@ class MarketData(TradierApiBase):
         symbols = symbols if isinstance(symbols, str) else ",".join(symbols)
         payload = {"symbols": symbols, greeks: greeks}
 
-        # Get response
-        response = self.request(self.QUOTES_ENDPOINT, payload)
+        # Get response, but retry if we don't get any data.
+        # Sometimes tradier responds but with no data, so the requests_retry_session doesn't retry.
+        response = None
+        for _ in range(DEFAULT_RETRY_ATTEMPTS):
+            response = self.request(self.QUOTES_ENDPOINT, payload)
+            if response["quotes"] and "quote" in response["quotes"]:
+                break
+            else:
+                logger.info(f"No data for {symbols} from get_quotes. Retrying.")
+                sleep(1)
 
         if "quote" not in response["quotes"]:
             raise ValueError(f"Invalid symbol: {payload['symbols']}")
@@ -128,6 +136,7 @@ class MarketData(TradierApiBase):
 
         # Get response, but retry if we don't get any data.
         # Sometimes tradier responds but with no data, so the requests_retry_session doesn't retry.
+        response = None
         for _ in range(DEFAULT_RETRY_ATTEMPTS):
             response = self.request(self.HISTORICAL_QUOTES_ENDPOINT, payload)
             if response["history"] and "day" in response["history"]:
@@ -191,7 +200,17 @@ class MarketData(TradierApiBase):
         if end_date:
             payload["end"] = self.date2str(end_date, include_min=True)
 
-        response = self.request(self.TIME_AND_SALES_ENDPOINT, payload)
+        # Get response, but retry if we don't get any data.
+        # Sometimes tradier responds but with no data, so the requests_retry_session doesn't retry.
+        response = None
+        for _ in range(DEFAULT_RETRY_ATTEMPTS):
+            response = self.request(self.TIME_AND_SALES_ENDPOINT, payload)
+            if response["series"] and "data" in response["series"]:
+                break
+            else:
+                logger.info(f"No data for {symbol} from get_timesales. Retrying.")
+                sleep(1)
+
         if response["series"] is None or "data" not in response["series"]:
             raise LookupError(
                 f"No Time and Sales found for: Symbol={payload['symbol']}, start={payload['start']}, "
@@ -239,8 +258,16 @@ class MarketData(TradierApiBase):
             "includeAllRoots": include_all_roots,
         }
 
-        # Get response
-        response = self.request(self.OPTION_EXPIRATIONS_ENDPOINT, payload)
+        # Get response, but retry if we don't get any data.
+        # Sometimes tradier responds but with no data, so the requests_retry_session doesn't retry.
+        response = None
+        for _ in range(DEFAULT_RETRY_ATTEMPTS):
+            response = self.request(self.OPTION_EXPIRATIONS_ENDPOINT, payload)
+            if response["expirations"] and "expiration" in response["expirations"]:
+                break
+            else:
+                logger.info(f"No data for {symbol} from get_option_expiration. Retrying.")
+                sleep(1)
 
         if not response["expirations"] or "expiration" not in response["expirations"]:
             raise LookupError(f"No Option Expirations found for: Symbol={payload['symbol']}")
@@ -274,8 +301,16 @@ class MarketData(TradierApiBase):
             "greeks": greeks,
         }
 
-        # Get response
-        response = self.request(self.OPTION_CHAIN_ENDPOINT, payload)
+        # Get response, but retry if we don't get any data.
+        # Sometimes tradier responds but with no data, so the requests_retry_session doesn't retry.
+        response = None
+        for _ in range(DEFAULT_RETRY_ATTEMPTS):
+            response = self.request(self.OPTION_CHAIN_ENDPOINT, payload)
+            if response["options"] and "option" in response["options"]:
+                break
+            else:
+                logger.info(f"No data for {symbol} from get_option_chains. Retrying.")
+                sleep(1)
 
         if not response["options"] or "option" not in response["options"]:
             raise LookupError(
@@ -305,8 +340,16 @@ class MarketData(TradierApiBase):
             "expiration": self.date2str(expiration),
         }
 
-        # Get response
-        response = self.request(self.OPTION_STRIKES_ENDPOINT, payload)
+        # Get response, but retry if we don't get any data.
+        # Sometimes tradier responds but with no data, so the requests_retry_session doesn't retry.
+        response = None
+        for _ in range(DEFAULT_RETRY_ATTEMPTS):
+            response = self.request(self.OPTION_STRIKES_ENDPOINT, payload)
+            if response["strikes"] and "strike" in response["strikes"]:
+                break
+            else:
+                logger.info(f"No data for {symbol} from get_option_strikes. Retrying.")
+                sleep(1)
 
         if not response["strikes"] or "strike" not in response["strikes"]:
             raise LookupError(
@@ -376,8 +419,16 @@ class MarketData(TradierApiBase):
             "year": str(year),
         }
 
-        # Get response
-        response = self.request(self.CALENDAR_ENDPOINT, payload)
+        # Get response, but retry if we don't get any data.
+        # Sometimes tradier responds but with no data, so the requests_retry_session doesn't retry.
+        response = None
+        for _ in range(DEFAULT_RETRY_ATTEMPTS):
+            response = self.request(self.CALENDAR_ENDPOINT, payload)
+            if response["calendar"] and "days" in response["calendar"]:
+                break
+            else:
+                logger.info(f"No data from get_calendar. Retrying.")
+                sleep(1)
 
         if not response["calendar"] or "days" not in response["calendar"]:
             raise LookupError(f"No Calendar found for: Month={payload['month']}, Year={payload['year']}")
@@ -419,8 +470,16 @@ class MarketData(TradierApiBase):
         if types:
             payload["types"] = types if isinstance(types, str) else ",".join(types)
 
-        # Get response
-        response = self.request(self.LOOKUP_SYMBOL_ENDPOINT, payload)
+        # Get response, but retry if we don't get any data.
+        # Sometimes tradier responds but with no data, so the requests_retry_session doesn't retry.
+        response = None
+        for _ in range(DEFAULT_RETRY_ATTEMPTS):
+            response = self.request(self.LOOKUP_SYMBOL_ENDPOINT, payload)
+            if response["securities"] and "security" in response["securities"]:
+                break
+            else:
+                logger.info(f"No data for {query} from lookup_symbol. Retrying.")
+                sleep(1)
 
         if not response["securities"] or "security" not in response["securities"]:
             raise LookupError(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,10 +1,50 @@
+import os
+import sys
 from pathlib import Path
-
+import logging
 from dotenv import load_dotenv
 
+logger = logging.getLogger(__name__)
+found_dotenv = False
+
+
+def find_and_load_dotenv(base_dir) -> bool:
+    for root, dirs, files in os.walk(base_dir):
+        logger.debug(f"Checking {root} for .env file")
+        if '.env' in files:
+            dotenv_path = os.path.join(root, '.env')
+            load_dotenv(dotenv_path)
+            logger.info(f".env file loaded from: {dotenv_path}")
+            return True
+
+    return False
+
+
+# First check for a .secrets folder. Unsure why this would load ALL the .envs in the folder but leaving
+# the behavior as is.
 # Load sensitive information such as API keys from .env files so that they are not stored in the repository
 # but can still be accessed by the tests through os.environ
 secrets_path = Path(__file__).parent.parent / '.secrets'
 if secrets_path.exists():
     for secret_file in secrets_path.glob('*.env'):
         load_dotenv(secret_file)
+        found_dotenv = True
+
+
+# Next, check the directory where script is being run
+script_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+logger.debug(f"script_dir: {script_dir}")
+found_dotenv = find_and_load_dotenv(script_dir)
+
+if not found_dotenv:
+    # Lastly, check the root directory of the project. This should probably be checked first,
+    # since it's what the readme says to do.
+    cwd_dir = os.getcwd()
+    logger.debug(f"cwd_dir: {cwd_dir}")
+    found_dotenv = find_and_load_dotenv(cwd_dir)
+
+# If no .env file was found, print a warning message
+if not found_dotenv:
+    # Create a colored message for the log using termcolor
+    msg = "No .env file found. please create a .env file in the root directory of the project."
+    logger.warning(msg)

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -14,6 +14,7 @@ def tradier():
 
 
 class TestOrders:
+
     def test_bad_order_inputs(self, tradier):
         with pytest.raises(ValueError):
             tradier.orders.order(symbol='AAPL', quantity=1, side='bad_side', order_type='market', tag='unittest')
@@ -223,3 +224,4 @@ class TestOrders:
         resp = tradier.orders.cancel(option_order['id'])
         assert resp
         assert resp['id'] == option_order['id']
+        

--- a/tests/test_tradier_api_base.py
+++ b/tests/test_tradier_api_base.py
@@ -1,0 +1,47 @@
+import os
+import time
+import requests
+
+
+from lumiwealth_tradier.base import TradierApiBase
+
+
+class TestTradierApiBase:
+
+    def setup_method(self):
+        tradier_acct = os.getenv('TRADIER_ACCOUNT_NUMBER')
+        tradier_token = os.getenv('TRADIER_PAPER_TOKEN')
+        self.tradier_api_base = TradierApiBase(tradier_acct, tradier_token, is_paper=True)
+
+    def test_retrying_rest_client(self):
+        assert self.tradier_api_base is not None
+
+    def test_non_retrying_request_raises_connection_error_quick(self):
+        t0 = time.time()
+        try:
+            response = requests.get(
+                'http://localhost:9999',
+            )
+        except Exception as e:
+            pass
+        else:
+            pass
+        finally:
+            t1 = time.time()
+            actual = t1 - t0
+            assert t1 - t0 < 1
+
+    def test_retrying_request_raises_connection_error_slower(self):
+        t0 = time.time()
+        try:
+            response = self.tradier_api_base.requests_retry_session(retries=2).get(
+                'http://localhost:9999',
+            )
+        except Exception as e:
+            pass
+        else:
+            pass
+        finally:
+            t1 = time.time()
+            actual = t1 - t0
+            assert t1 - t0 > 5


### PR DESCRIPTION
This PR addresses two common problems:
1. Sometimes the tradier API is down or there's a network hiccup and requests don't succeed.
2. Sometimes tradier responds, but provides no data.

For case 1, this PR introduces a retrying request session which automatically retires requests that fail with certain HTTP status codes. Its only implemented for get requests (since these all seem to be idempotent - meaning they can be harmlessly retried). I didnt feel comfortable implementing this for posts, deteles, etc.... 

Case two was only address for get_historical_quotes, which is the main reason for this PR. It seems that sometimes tradier just doesnt return data even though it responded. In this case, the session retry won't kick in because the server responded successfully. So I just loop and retry 3 times. This is simple but it works.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement retry logic for HTTP GET requests in the `TradierApiBase` class to handle transient errors and retry when no data is received, update the README guide for contributors, and add new test cases to verify retry behavior.

### Why are these changes being made?

These changes improve the resilience of the API interactions by automatically retrying failed or empty responses, enhancing user experience and reducing manual intervention. The README guide now provides updated instructions for setting up development environments, aligning with best practices. The tests included ensure robustness by validating the retry mechanism’s functionality and effectiveness.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->