### PR TITLE
Modify Orders Fixes

### DIFF
--- a/lumiwealth_tradier/base.py
+++ b/lumiwealth_tradier/base.py
@@ -125,10 +125,12 @@ class TradierApiBase:
                 )
             elif method == "post":
                 r = requests.post(url=f"{self.base_url()}/{endpoint}", params=params, headers=headers, data=data)
+            elif method == "put":
+                r = requests.put(url=f"{self.base_url()}/{endpoint}", params=params, headers=headers, data=data)
             elif method == "delete":
                 r = requests.delete(url=f"{self.base_url()}/{endpoint}", params=params, data=data, headers=headers)
             else:
-                raise ValueError(f"Invalid method {method}. Must be one of ['get', 'post', 'delete']")
+                raise ValueError(f"Invalid method {method}. Must be one of ['get', 'post', 'put', 'delete']")
 
             # Check for errors in response from Tradier API.
             # 502 is a common error code when the API is down for a few seconds so we ignore it too.
@@ -161,7 +163,7 @@ class TradierApiBase:
 
         return ret_data
 
-    def send(self, endpoint, data, headers=None) -> dict:
+    def send(self, endpoint, data, headers=None, method="put") -> dict:
         """
         This function sends a post request to the Tradier API and returns a json object.
         :param endpoint: Tradier API endpoint
@@ -169,7 +171,9 @@ class TradierApiBase:
         :param headers: Dictionary of requests.post() headers to pass to the endpoint
         :return: json object
         """
-        return self.request(endpoint, params={}, headers=headers, data=data, method="post")
+        if method.lower() not in ["put", "post"]:
+            raise ValueError(f"Invalid method {method}. Must be one of ['put', 'post']")
+        return self.request(endpoint, params={}, headers=headers, data=data, method=method.lower())
 
     def requests_retry_session(
             self,
@@ -195,4 +199,3 @@ class TradierApiBase:
         session.mount('http://', adapter)
         session.mount('https://', adapter)
         return session
-    

--- a/lumiwealth_tradier/orders.py
+++ b/lumiwealth_tradier/orders.py
@@ -142,20 +142,19 @@ class Orders(TradierApiBase):
         :param stop_price: Stop price. Required for stop and stop_limit orders.
         :return: json object
         """
-        if duration.lower() not in self.valid_durations:
-            raise ValueError(f"Invalid duration. Must be one of {self.valid_durations}")
-
         payload = {
             "order_id": order_id,
         }
         if duration:
+            if duration.lower() not in self.valid_durations:
+                raise ValueError(f"Invalid duration. Must be one of {self.valid_durations}")
             payload["duration"] = duration.lower()
         if limit_price:
             payload["price"] = limit_price
         if stop_price:
             payload["stop"] = stop_price
 
-        response = self.send(f"{self.ORDER_ENDPOINT}/{order_id}", payload)
+        response = self.send(f"{self.ORDER_ENDPOINT}/{order_id}", payload, method="put")
         return response["order"]
 
     def order(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", encoding="utf-8") as fh:
 
 setup(
     name="lumiwealth-tradier",
-    version="0.1.14",
+    version="0.1.15",
     author="David MacLeod and Robert Grzesik",
     description="lumiwealth-tradier is a Python package that serves as a wrapper for the Tradier brokerage API. "
     "This package simplifies the process of making API requests, handling responses, and performing various trading "


### PR DESCRIPTION
Modify orders has been updated to use the "put" requests method instead of "post". Paper trading discovered that Tradier was rejecting the "post" version and orders were not being updated.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement the "put" HTTP method for API requests in the `base.py` and `orders.py`modules, updating the default request method in the `send` function to "put", and incrementing the package version to 0.1.15.

### Why are these changes being made?

To enable the modification of existing orders on the Tradier API using the "put" HTTP method, aligning with standard RESTful practices, and validating this method alongside "post". This enhances the functionality for order modification, ensuring compliance with API standards and improving the package's robustness in handling API interactions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->