### PR TITLE
update modify method to set default duration and improve error messages

### DIFF
--- a/lumiwealth_tradier/orders.py
+++ b/lumiwealth_tradier/orders.py
@@ -126,7 +126,7 @@ class Orders(TradierApiBase):
     def modify(
         self,
         order_id: int,
-        duration: str = "",
+        duration: str = "day",
         limit_price: Union[float, None] = None,
         stop_price: Union[float, None] = None,
     ) -> dict:
@@ -147,7 +147,7 @@ class Orders(TradierApiBase):
         }
         if duration:
             if duration.lower() not in self.valid_durations:
-                raise ValueError(f"Invalid duration. Must be one of {self.valid_durations}")
+                raise ValueError(f"Invalid duration '{duration}'). Must be one of {self.valid_durations}")
             payload["duration"] = duration.lower()
         if limit_price:
             payload["price"] = limit_price
@@ -382,8 +382,8 @@ class Orders(TradierApiBase):
         if order_class.lower() not in ["oco", "oto", "otoco"]:
             raise ValueError(f"Invalid advanced order class '{order_class}'. Must be one of ['oco', 'oto', 'otoco']")
 
-        # Ensure there are exactly 2 legs for OTO and OTO orders. OTOCO (aka Bracket) order can have more than 2
-        if len(legs) != 2 and order_class.lower() in ["oto", "oto"]:
+        # Ensure there are exactly 2 legs for OCO and OTO orders. OTOCO (aka Bracket) order can have more than 2
+        if len(legs) != 2 and order_class.lower() in ["oco", "oto"]:
             raise ValueError(f"An {order_class.upper()} order must have exactly 2 legs.")
 
         # Start constructing the data payload

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -89,6 +89,14 @@ class TestOrders:
         assert resp
         assert resp['id'] == option_order['id']
 
+    def test_modify_order(self, tradier, mocker):
+        mocker.patch.object(tradier.orders, 'send', return_value={'order': {'id': 123, 'status': 'ok'}})
+        with pytest.raises(ValueError):
+            tradier.orders.modify(order_id=123, duration='bad_duration', limit_price=1.0)
+
+        res = tradier.orders.modify(order_id=123, stop_price=1.0)
+        assert res
+
     def test_option_order_multileg(self, tradier):
         from lumiwealth_tradier.orders import OrderLeg
 


### PR DESCRIPTION
Small updates to improve logging and error messages.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the `modify` method to set a default order duration of "day" and improve error messages for invalid durations and leg count checks. Also, introduce a new test case for the `modify` method.

### Why are these changes being made?

The default duration ensures orders without specified durations do not fail, enhancing user experience. Improved error messages provide clearer guidance for correcting input errors, which supports debugging and usage. The new test case validates the modified behavior of the `modify` method ensuring correctness and robustness.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->