### PR TITLE
Modify Order Duration default removed.

### DIFF
--- a/lumiwealth_tradier/orders.py
+++ b/lumiwealth_tradier/orders.py
@@ -126,7 +126,7 @@ class Orders(TradierApiBase):
     def modify(
         self,
         order_id: int,
-        duration: str = "day",
+        duration: str = "",
         limit_price: Union[float, None] = None,
         stop_price: Union[float, None] = None,
     ) -> dict:


### PR DESCRIPTION
This pull request makes a small change to the `modify` method in the `lumiwealth_tradier/orders.py` file. The default value for the `duration` parameter has been changed from `"day"` to an empty string. This is based upon feedback from Tradier Support that it is better not to provide a duration when changing other parameters.

* [`lumiwealth_tradier/orders.py`](diffhunk://#diff-68e51226784effe4af725be4fba7e39aa497e71282acef59aaa43be73ccf8d08L129-R129): Changed the default value of the `duration` parameter in the `modify` method to an empty string.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the default value for the `duration` parameter in the `modify` function within `orders.py`.

### Why are these changes being made?

The intention is to enforce explicit specification of the `duration` parameter for order modifications, ensuring clarity and potentially reducing errors due to unintended defaults. This change reflects a design decision to prioritize explicit configuration over implicit defaults to enhance robustness.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->