### PR TITLE
add support for retrying 401

### DIFF
--- a/lumiwealth_tradier/base.py
+++ b/lumiwealth_tradier/base.py
@@ -16,9 +16,7 @@ DEFAULT_RETRY_ATTEMPTS = 3
 DEFAULT_RETRY_BACKOFF_FACTOR = 3.06
 DEFAULT_RETRY_WAIT_SECONDS = 3
 DEFAULT_CONNECTION_TIMEOUT = 10
-DEFAULT_RETRY_HTTP_STATUS_CODES: List[int] = [409, 429, 500, 502, 503, 504, 520, 530]
-# Don't retry these as they are not transient errors:
-# 401 - Unauthorized
+DEFAULT_RETRY_HTTP_STATUS_CODES: List[int] = [401, 409, 429, 500, 502, 503, 504, 520, 530]
 
 # https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.retry.Retry
 DEFAULT_ALLOWED_METHODS = frozenset(['GET'])

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", encoding="utf-8") as fh:
 
 setup(
     name="lumiwealth-tradier",
-    version="0.1.17",
+    version="0.1.18",
     author="David MacLeod and Robert Grzesik",
     description="lumiwealth-tradier is a Python package that serves as a wrapper for the Tradier brokerage API. "
     "This package simplifies the process of making API requests, handling responses, and performing various trading "

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -52,8 +52,8 @@ class TestMarket:
         # Get the quote for the option
         df = tradier.market.get_quotes([symbol])
         assert df is not None
-        assert 'last' in df.columns
-        assert df.loc[symbol]['last'] > 0
+        assert 'bid' in df.columns
+        assert df.loc[symbol]['bid'] > 0
 
     def test_historical_quote(self, tradier):
         # Multiple row return


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add support for retrying HTTP status code 401 by including it in the list of default retryable status codes and update the version to 0.1.18.

### Why are these changes being made?

Including 401 in the retry list addresses scenarios where tokens might be temporarily invalid and will become valid upon retry, thus enhancing the API wrapper's resilience. Additionally, version increment ensures that the package consumers are aware of this enhancement. The test has been updated to verify the presence and accuracy of "bid" rather than "last" to reflect a more appropriate validation metric.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->